### PR TITLE
Get PORT env for dokku(-alt) apps

### DIFF
--- a/assets/tor_config.py
+++ b/assets/tor_config.py
@@ -11,8 +11,9 @@ def set_conf():
     with open("/etc/tor/torrc", "a") as conf:
         for link in links:
             path = "/var/lib/tor/hidden_service/{service}".format(service=link)
+            env_port = links[link]['environment'].get('PORT')
             # Test if link has ports
-            if len(links[link]['ports']) == 0:
+            if len(links[link]['ports']) == 0 and not env_port:
                 print("{link} has no port")
                 continue
             conf.write('HiddenServiceDir {path}\n'.format(path=path))
@@ -22,6 +23,13 @@ def set_conf():
                     continue
                 service = '{port} {ip}:{port}'.format(
                     port=port, ip=links[link]['ip']
+                )
+                conf.write('HiddenServicePort {service}\n'.format(
+                    service=service
+                ))
+            if env_port:
+                service = '{port} {ip}:{port}'.format(
+                     port=env_port, ip=links[link]['ip']
                 )
                 conf.write('HiddenServicePort {service}\n'.format(
                     service=service

--- a/assets/tor_config.py
+++ b/assets/tor_config.py
@@ -28,7 +28,7 @@ def set_conf():
                     service=service
                 ))
             if env_port:
-                service = '{port} {ip}:{port}'.format(
+                service = '80 {ip}:{port}'.format(
                      port=env_port, ip=links[link]['ip']
                 )
                 conf.write('HiddenServicePort {service}\n'.format(


### PR DESCRIPTION
I'm using [dokku-alt][] for deploying my apps.
dokku doesn't expose any port, but it set `PORT` environment to bind and connect internally.
This commit enables tor hidden service for that.

[dokku-alt]: https://github.com/dokku-alt/dokku-alt