### PR TITLE
install latest version of tor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM    alpine
 
 ENV     HOME /var/lib/tor
-ENV     TOR_VERSION 0.2.8.8
 
 RUN     apk add --no-cache git libevent-dev openssl-dev gcc make automake ca-certificates autoconf musl-dev && \
         mkdir -p /usr/local/src/ && \
         git clone https://git.torproject.org/tor.git /usr/local/src/tor && \
         cd /usr/local/src/tor && \
-        git checkout tor-${TOR_VERSION} && \
+        git checkout $(git tag | tail -1) && \
         ./autogen.sh && \
         ./configure \
             --disable-asciidoc \


### PR DESCRIPTION
instead of maintaining an environmental variable the script now
goes for the latest tag known to the git repo.