### PR TITLE
Enables configuration of Tor's control port

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAACArobDQYyZAWXei4QZwr++j96H1X/gq14NwLRZ
 
 Set tor sock5 proxy port for this tor instance. (Use this if you need to connect to tor network with your service)
 
+##### `TOR_CONTROL_PORT`, `TOR_CONTROL_AUTH_PASSWORD, `TOR_CONTROL_AUTH_COOKIE`
+
+Enable tor control port and auth (see doc https://2019.www.torproject.org/docs/tor-manual.html.en)
+
+Keys are stored in `/var/lib/tor/hidden_service/`
+
 
 #### Secrets
 

--- a/assets/entrypoint-config.yml
+++ b/assets/entrypoint-config.yml
@@ -9,6 +9,9 @@ secret_env:
     - '*_SERVICE_NAME'
     - '*_TOR_SERVICE_*'
     - 'TOR_SOCKS_PORT'
+    - 'TOR_CONTROL_PORT'
+    - 'TOR_CONTROL_AUTH_PASSWORD'
+    - 'TOR_CONTROL_AUTH_COOKIE'
 
 pre_conf_commands:
     - onions --setup-hosts

--- a/assets/torrc
+++ b/assets/torrc
@@ -25,4 +25,16 @@ SocksPort {{env['TOR_SOCKS_PORT']}}
 SocksPort 0
 {% endif %}
 
+DataDirectory /var/lib/tor/hidden_service
+
+{% if 'TOR_CONTROL_PORT' in env %}
+ControlPort {{env['TOR_CONTROL_PORT']}}
+{% if 'TOR_CONTROL_AUTH_PASSWORD' in env %}
+HashedControlPassword {{env['TOR_CONTROL_AUTH_PASSWORD']}}
+{% endif %}
+{% if 'TOR_CONTROL_AUTH_COOKIE' in env %}
+CookieAuthentication 1
+{% endif %}
+{% endif %}
+
 # useless line for Jinja bug


### PR DESCRIPTION
The patch adds a single commit which enables configuration of Tor's control port. Once merged, your project can be used in conjuction with vanguards, an addon which increases privacy of a hidden service.

I received this patch by mail, I need to check if DataDirectory in root of all hidden services don't have any to side effect.