### PR TITLE
Dockerfile: Add torsocks binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM    python:3.8-alpine
 ARG     tor_version
+ARG     torsocks_version
 
 ENV     HOME /var/lib/tor
 ENV     POETRY_VIRTUALENVS_CREATE=false
@@ -20,6 +21,17 @@ RUN     apk add --no-cache git bind-tools libevent-dev openssl-dev gnupg gcc mak
     pip3 install --upgrade pip poetry && \
     apk del git libevent-dev openssl-dev gnupg make automake autoconf musl-dev coreutils libffi-dev && \
     apk add --no-cache libevent openssl
+
+RUN    apk add --no-cache git gcc make automake autoconf musl-dev libtool && \
+    git clone https://git.torproject.org/torsocks.git /usr/local/src/torsocks && \
+    cd /usr/local/src/torsocks && \
+    git checkout $torsocks_version && \
+    ./autogen.sh && \
+    ./configure && \
+    make && make install && \
+    cd .. && \
+    rm -rf torsocks && \
+    apk del git gcc make automake autoconf musl-dev libtool
 
 RUN     mkdir -p /etc/tor/
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .EXPORT_ALL_VARIABLES:
 
 TOR_VERSION = $(shell bash last_tor_version.sh)
+TORSOCKS_VERSION = $(shell bash last_torsocks_version.sh)
 CUR_COMMIT = $(shell git rev-parse --short HEAD)
 CUR_TAG = v$(TOR_VERSION)-$(CUR_COMMIT)
 
@@ -17,11 +18,11 @@ check:
 	pre-commit run --all-files
 
 build:
-	- echo build with tor version $(TOR_VERSION)
+	- echo build with tor version $(TOR_VERSION) and torsocks version $(TORSOCKS_VERSION)
 	docker-compose -f docker-compose.build.yml build
 
 rebuild:
-	- echo rebuild with tor version $(TOR_VERSION)
+	- echo rebuild with tor version $(TOR_VERSION) and torsocks version $(TORSOCKS_VERSION)
 	docker-compose -f docker-compose.build.yml build --no-cache
 
 run: build

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -9,3 +9,4 @@ services:
       context: .
       args:
         tor_version: $TOR_VERSION
+        torsocks_version: $TORSOCKS_VERSION

--- a/last_torsocks_version.sh
+++ b/last_torsocks_version.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+git ls-remote --tags https://git.torproject.org/torsocks.git | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1


### PR DESCRIPTION
This has two purposes:
1) The 'torify' wrapper is already included, and it needs torsocks.
2) Use torsocks for health checking your onion service like this:
``` 
healthcheck:
  test: ["CMD-SHELL", "torsocks nc -z <onion address> <port> || exit 1"]
  start_period: 2m
  interval: 1m
```

This is a draft, though I'm already running this in production.

This PR currently includes #54, I'll rebase once that is merged.

I've hardcoded this to torsocks v2.3.0 atm because I don't know what works best for your project. We could also use the latest master, or make the tag configurable via build argument. Or we could install torsocks from the Alpine repository, but I assume it would also pull in a second copy of tor.

Also, actually I don't know if it is a good idea from a privacy point of view to connect to a hidden service that's on the machine.
