### PR TITLE
Default to HiddenServiceVersion=3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,30 +20,10 @@ services:
       - again
     environment:
         # Set mapping ports
-        SERVICE1_TOR_SERVICE_HOSTS: 80:hello:80,800:hello:80,8888:hello:80
-        # Set private key
+        SERVICE1_TOR_SERVICE_HOSTS: 88:again:80,8000:world:80
+         # Set private key
+        # Tor v3 address private key must be base 64 encoded
         SERVICE1_TOR_SERVICE_KEY: |
-            -----BEGIN RSA PRIVATE KEY-----
-            MIICXQIBAAKBgQDR8TdQF9fDlGhy1SMgfhMBi9TaFeD12/FK27TZE/tYGhxXvs1C
-            NmFJy1hjVxspF5unmUsCk0yEsvEdcAdp17Vynz6W41VdinETU9yXHlUJ6NyI32AH
-            dnFnHEcsllSEqD1hPAAvMUWwSMJaNmBEFtl8DUMS9tPX5fWGX4w5Xx8dZwIDAQAB
-            AoGBAMb20jMHxaZHWg2qTRYYJa8LdHgS0BZxkWYefnBUbZn7dOz7mM+tddpX6raK
-            8OSqyQu3Tc1tB9GjPLtnVr9KfVwhUVM7YXC/wOZo+u72bv9+4OMrEK/R8xy30XWj
-            GePXEu95yArE4NucYphxBLWMMu2E4RodjyJpczsl0Lohcn4BAkEA+XPaEKnNA3AL
-            1DXRpSpaa0ukGUY/zM7HNUFMW3UP00nxNCpWLSBmrQ56Suy7iSy91oa6HWkDD/4C
-            k0HslnMW5wJBANdz4ehByMJZmJu/b5y8wnFSqep2jmJ1InMvd18BfVoBTQJwGMAr
-            +qwSwNXXK2YYl9VJmCPCfgN0o7h1AEzvdYECQAM5UxUqDKNBvHVmqKn4zShb1ugY
-            t1RfS8XNbT41WhoB96MT9P8qTwlniX8UZiwUrvNp1Ffy9n4raz8Z+APNwvsCQQC9
-            AuaOsReEmMFu8VTjNh2G+TQjgvqKmaQtVNjuOgpUKYv7tYehH3P7/T+62dcy7CRX
-            cwbLaFbQhUUUD2DCHdkBAkB6CbB+qhu67oE4nnBCXllI9EXktXgFyXv/cScNvM9Y
-            FDzzNAAfVc5Nmbmx28Nw+0w6pnpe/3m0Tudbq3nHdHfQ
-            -----END RSA PRIVATE KEY-----
-
-        # hello and again will share the same onion v3 address
-        SERVICE2_TOR_SERVICE_HOSTS: 88:again:80,8000:world:80
-        SERVICE2_TOR_SERVICE_VERSION: '3'
-        # tor v3 address private key base 64 encoded
-        SERVICE2_TOR_SERVICE_KEY: |
             PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAACArobDQYyZAWXei4QZwr++
             j96H1X/gq14NwLRZ2O5DXuL0EzYKkdhZSILY85q+kfwZH8z4ceqe7u1F+0pQi/sM
 
@@ -63,16 +43,11 @@ services:
 This configuration will output:
 
 ```
-service2: xwjtp3mj427zdp4tljiiivg2l5ijfvmt5lcsfaygtpp6cw254kykvpyd.onion:88, xwjtp3mj427zdp4tljiiivg2l5ijfvmt5lcsfaygtpp6cw254kykvpyd.onion:8000
-service1: 5azvyr7dvvr4cldn.onion:80, 5azvyr7dvvr4cldn.onion:800, 5azvyr7dvvr4cldn.onion:8888
+service1: xwjtp3mj427zdp4tljiiivg2l5ijfvmt5lcsfaygtpp6cw254kykvpyd.onion:88, xwjtp3mj427zdp4tljiiivg2l5ijfvmt5lcsfaygtpp6cw254kykvpyd.onion:8000
 ```
 
 `xwjtp3mj427zdp4tljiiivg2l5ijfvmt5lcsfaygtpp6cw254kykvpyd.onion:88` will hit `again:80`.
 `xwjtp3mj427zdp4tljiiivg2l5ijfvmt5lcsfaygtpp6cw254kykvpyd.onion:8000` will hit `wold:80`.
-
-`5azvyr7dvvr4cldn.onion:80` will hit `hello:80`.
-`5azvyr7dvvr4cldn.onion:800` will hit `hello:80` too.
-`5azvyr7dvvr4cldn.onion:8888` will hit `hello:80` again.
 
 #### Environment variables
 
@@ -88,40 +63,16 @@ You can concatenate services using comas.
 
 > **WARNING**: Using sockets and ports in the same service group can lead to issues
 
-##### `{SERVICE}_TOR_SERVICE_VERSION`
-
-Can be `2` or `3`. Set the tor address type.
-
-`2` gives short addresses `5azvyr7dvvr4cldn.onion` and `3` long addresses `xwjtp3mj427zdp4tljiiivg2l5ijfvmt5lcsfaygtpp6cw254kykvpyd.onion`
-
 
 ##### `{SERVICE}_TOR_SERVICE_KEY`
 
 You can set the private key for the current service.
 
-Tor v2 addresses uses RSA PEM keys like:
-```
------BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQDR8TdQF9fDlGhy1SMgfhMBi9TaFeD12/FK27TZE/tYGhxXvs1C
-NmFJy1hjVxspF5unmUsCk0yEsvEdcAdp17Vynz6W41VdinETU9yXHlUJ6NyI32AH
-dnFnHEcsllSEqD1hPAAvMUWwSMJaNmBEFtl8DUMS9tPX5fWGX4w5Xx8dZwIDAQAB
-AoGBAMb20jMHxaZHWg2qTRYYJa8LdHgS0BZxkWYefnBUbZn7dOz7mM+tddpX6raK
-8OSqyQu3Tc1tB9GjPLtnVr9KfVwhUVM7YXC/wOZo+u72bv9+4OMrEK/R8xy30XWj
-GePXEu95yArE4NucYphxBLWMMu2E4RodjyJpczsl0Lohcn4BAkEA+XPaEKnNA3AL
-1DXRpSpaa0ukGUY/zM7HNUFMW3UP00nxNCpWLSBmrQ56Suy7iSy91oa6HWkDD/4C
-k0HslnMW5wJBANdz4ehByMJZmJu/b5y8wnFSqep2jmJ1InMvd18BfVoBTQJwGMAr
-+qwSwNXXK2YYl9VJmCPCfgN0o7h1AEzvdYECQAM5UxUqDKNBvHVmqKn4zShb1ugY
-t1RfS8XNbT41WhoB96MT9P8qTwlniX8UZiwUrvNp1Ffy9n4raz8Z+APNwvsCQQC9
-AuaOsReEmMFu8VTjNh2G+TQjgvqKmaQtVNjuOgpUKYv7tYehH3P7/T+62dcy7CRX
-cwbLaFbQhUUUD2DCHdkBAkB6CbB+qhu67oE4nnBCXllI9EXktXgFyXv/cScNvM9Y
-FDzzNAAfVc5Nmbmx28Nw+0w6pnpe/3m0Tudbq3nHdHfQ
------END RSA PRIVATE KEY-----
-```
-
 Tor v3 addresses uses ed25519 binary keys. It should be base64 encoded:
 ```
 PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAACArobDQYyZAWXei4QZwr++j96H1X/gq14NwLRZ2O5DXuL0EzYKkdhZSILY85q+kfwZH8z4ceqe7u1F+0pQi/sM
 ```
+
 ##### `TOR_SOCKS_PORT`
 
 Set tor sock5 proxy port for this tor instance. (Use this if you need to connect to tor network with your service)

--- a/assets/torrc
+++ b/assets/torrc
@@ -1,8 +1,6 @@
 {% for service_group in onion.services %}
 HiddenServiceDir {{service_group.hidden_service_dir}}
-    {% if service_group.version == 3 %}
 HiddenServiceVersion 3
-    {% endif %}
     {% for service in service_group.services %}
         {% for port in service.ports %}
             {% if port.is_socket %}

--- a/docker-compose.v2.yml
+++ b/docker-compose.v2.yml
@@ -32,7 +32,6 @@ services:
 
         # hello and again will share the same onion_adress
         FOO_TOR_SERVICE_HOSTS: 88:again:80,8000:world:80
-        FOO_TOR_SERVICE_VERSION: '3'
         # tor v3 address private key base 64 encoded
         FOO_TOR_SERVICE_KEY: |
             PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAABYZRzL3zScTEqA8/5wfvHw

--- a/docker-compose.v3.latest.yml
+++ b/docker-compose.v3.latest.yml
@@ -12,7 +12,6 @@ services:
     environment:
         # Set version 3 on BAR group
         BAR_TOR_SERVICE_HOSTS: '80:hello:80,88:world:80'
-        BAR_TOR_SERVICE_VERSION: '3'
 
         # hello and again will share the same v2 onion_adress
         FOO_TOR_SERVICE_HOSTS: '88:again:80,80:hello:80,800:hello:80,8888:hello:80'

--- a/docker-compose.v3.yml
+++ b/docker-compose.v3.yml
@@ -12,7 +12,6 @@ services:
     environment:
         # Set version 3 on BAR group
         BAR_TOR_SERVICE_HOSTS: '80:hello:80,88:world:80'
-        BAR_TOR_SERVICE_VERSION: '3'
 
         # hello and again will share the same v2 onion_adress
         FOO_TOR_SERVICE_HOSTS: '88:again:80,80:hello:80,800:hello:80,8888:hello:80'

--- a/docker-compose.vanguards-network.yml
+++ b/docker-compose.vanguards-network.yml
@@ -19,7 +19,6 @@ services:
           loglevel = DEBUG
 
         HELLO_TOR_SERVICE_HOSTS: '80:hello:80'
-        HELLO_TOR_SERVICE_VERSION: '3'
 
     # Keep keys in volumes
     volumes:

--- a/docker-compose.vanguards.yml
+++ b/docker-compose.vanguards.yml
@@ -16,8 +16,6 @@ services:
           loglevel = DEBUG
 
         HELLO_TOR_SERVICE_HOSTS: '80:hello:80'
-        HELLO_TOR_SERVICE_VERSION: '3'
-
 
     # Keep keys in volumes
     volumes:

--- a/tests/onions_test.py
+++ b/tests/onions_test.py
@@ -69,9 +69,7 @@ def get_torrc_template():
     return r"""
 {% for service_group in onion.services %}
 HiddenServiceDir {{service_group.hidden_service_dir}}
-    {% if service_group.version == 3 %}
 HiddenServiceVersion 3
-    {% endif %}
     {% for service in service_group.services %}
         {% for port in service.ports %}
             {% if port.is_socket %}
@@ -251,7 +249,6 @@ def test_key_v2(monkeypatch):
     envs = [
         {
             "GROUP1_TOR_SERVICE_HOSTS": "80:service1:80,81:service2:80",
-            "GROUP1_TOR_SERVICE_VERSION": "2",
             "GROUP1_TOR_SERVICE_KEY": key,
         },
         {
@@ -277,7 +274,6 @@ def test_key_v3(monkeypatch):
     key, onion_url = get_key_and_onion(version=3)
     env = {
         "GROUP1_TOR_SERVICE_HOSTS": "80:service1:80,81:service2:80",
-        "GROUP1_TOR_SERVICE_VERSION": "3",
         "GROUP1_TOR_SERVICE_KEY": key,
     }
 
@@ -298,7 +294,6 @@ def test_key_in_secret(fs, monkeypatch):
         "GROUP1_TOR_SERVICE_HOSTS": "80:service1:80",
         "GROUP2_TOR_SERVICE_HOSTS": "80:service2:80",
         "GROUP3_TOR_SERVICE_HOSTS": "80:service3:80",
-        "GROUP3_TOR_SERVICE_VERSION": "3",
     }
 
     monkeypatch.setattr(os, "environ", env)
@@ -335,11 +330,8 @@ HiddenServiceSingleHopMode 1
         "SERVICE1_PORTS": "80:80",
         "SERVICE2_PORTS": "81:80,82:8000",
         "SERVICE3_PORTS": "80:unix://unix.socket",
-        "GROUP3_TOR_SERVICE_VERSION": "2",
         "GROUP3_TOR_SERVICE_HOSTS": "80:service4:888,81:service5:8080",
-        "GROUP4_TOR_SERVICE_VERSION": "3",
         "GROUP4_TOR_SERVICE_HOSTS": "81:unix://unix2.sock",
-        "GROUP3V3_TOR_SERVICE_VERSION": "3",
         "GROUP3V3_TOR_SERVICE_HOSTS": "80:service4:888,81:service5:8080",
         "SERVICE5_TOR_SERVICE_HOSTS": "80:service5:80",
         "TOR_EXTRA_OPTIONS": extra_options,


### PR DESCRIPTION
This likely needs input/feedback from you before merging, but I've noticed users complaining that when not specifying the HiddenService version this container defaults to 2, which no longer is supported by the Tor network.

This PR defaults to `HiddenServiceVersion 3` in /etc/torrc and updates the README and example Docker Compose files to reflect this change.